### PR TITLE
build: Guard GOV.UK Frontend assets STATICFILES_DIRS mapping on the directory existing

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -205,8 +205,11 @@ STORAGES = {
 STATICFILES_DIRS = [
     BASE_DIR / "core" / "static",  # build.js output (JavaScript + CSS)
     ("images", BASE_DIR / "src" / "images"),  # served at /static/images/
-    ("govuk", BASE_DIR / "node_modules" / "govuk-frontend" / "govuk" / "assets"),  # served at /static/govuk/
 ]
+
+GOVUK_ASSETS_DIR = BASE_DIR / "node_modules" / "govuk-frontend" / "govuk" / "assets"
+if GOVUK_ASSETS_DIR.is_dir():
+    STATICFILES_DIRS.append(("govuk", GOVUK_ASSETS_DIR))  # served at /static/govuk/
 
 # https://docs.djangoproject.com/en/5.2/topics/logging/#django-security
 LOGGING = {


### PR DESCRIPTION
GOV.UK Frontend is a devDependency (789a202), so its assets directory exists
only in the build stage, where collectstatic hashes the referenced assets into
STATIC_ROOT. Building the CSS shows the compiled output references exactly two
govuk assets — govuk-crest.png and govuk-crest-2x.png, from the footer
component's .govuk-footer__copyright-logo rule. (No font files: the
$govuk-font-family override to arial/helvetica emits no GDS Transport
@font-face.) The custom footer never renders the copyright-logo element, so the
crest is never visible, but its url() is still baked into the compiled footer
CSS, and ManifestStaticFilesStorage must resolve it at collectstatic time — the
reason the mapping exists.

The Dockerfile_django runtime stage copies just the staticfiles.json manifest,
not node_modules, so at runtime the mapped directory is absent and Django's
system checks emit staticfiles.W004. Only add the ("govuk", ...) mapping when
the directory is present. The build stage still collects and hashes the assets;
the runtime image no longer warns.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176aBfnBRkrhGNMd4yKMBLV