### PR TITLE
Change footer attribution to Open Contracting Partnership

### DIFF
--- a/core/templates/includes/footer.html
+++ b/core/templates/includes/footer.html
@@ -68,7 +68,7 @@
           {% endcache %}
         </ul>
         <div class="govuk-footer__meta-custom">
-          {% trans 'Built by the' %} <a href="https://www.gov.uk/government/organisations/government-digital-service" class="govuk-footer__link">{% trans 'Government Digital Service' %}</a>
+          {% trans 'Maintained by' %}<a href=“http://www.open-contracting.org”>Open Contracting Partnership</a>. {% trans 'Originally developed by the' %} <a href="https://www.gov.uk/government/organisations/government-digital-service" class="govuk-footer__link">{% trans 'Government Digital Service' %}</a>.
         </div>
 
         <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
@@ -76,7 +76,7 @@
         </svg>
         <span class="govuk-footer__licence-description">
           {% trans 'All content is available under the' %}
-          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">{% trans 'Open Government Licence v3.0' %}</a>, {% trans 'except where otherwise stated' %}
+          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">{% trans 'Open Government Licence v3.0' %}</a>, {% trans 'except where otherwise stated' %}.
         </span>
       </div>
     </div>


### PR DESCRIPTION
Updated footer text to reflect maintenance by Open Contracting Partnership.